### PR TITLE
group_vars for windows boxes for winrm.

### DIFF
--- a/group_vars/windows.yml
+++ b/group_vars/windows.yml
@@ -1,0 +1,5 @@
+---
+# ansible_user: icpc
+# ansible_password: icpc2022a
+ansible_connection: winrm
+ansible_port: 5985


### PR DESCRIPTION
This was suppose to be part of #80 