### PR TITLE
Allow for adding custom iptables rules

### DIFF
--- a/roles/icpc_host_backup/templates/iptables.rules.j2
+++ b/roles/icpc_host_backup/templates/iptables.rules.j2
@@ -146,6 +146,8 @@
 -A INPUT -i {{ green_network_ifc }} -j DROP
 {% endif -%}
 
+{{ extra_iptables_rules | default([]) | join("\n") }}
+
 # drop rest
 -A OUTPUT -j drop-n-log
 -A INPUT -j drop-n-log


### PR DESCRIPTION
This it to better enable a system test environment, where the firewall rules may need to differ slightly from the real contest setup.