### PR TITLE
Let green presentation clients use script server

### DIFF
--- a/host_vars/backup.yml
+++ b/host_vars/backup.yml
@@ -51,6 +51,25 @@ script_server_commands:
       - name: hostname
         env_var: PARAM_HOSTNAME
         type: text
+        # audit_name comes from here: https://github.com/bugy/script-server/blob/bbb558510ed0758794d1f6c37c3964c4befbc1b8/src/utils/audit_utils.py#L58
+        # tl;dr: it's the first found value in [AUTH_USERNAME, PROXIED_USERNAME, PROXIED_HOSTNAME, PROXIED_IP, HOSTNAME, IP]
+        # Proxy IP comes from X-forwarded-for or x-real-ip headers
+        # Proxied username is actually just basic auth (but ignoring the credentials part of it?)
+        default: ${auth.audit_name}
+        constant: true
+        required: true
+
+  - name: run-lastminute-windows
+    description: Runs windows_lastminute.yml
+    group: ansible # for organization in script-server
+    content: |
+      #!/usr/bin/bash -ex
+      cd /root/ansible
+      ansible-playbook --limit "$PARAM_HOSTNAME" windows_lastminute.yml
+    parameters:
+      - name: hostname
+        env_var: PARAM_HOSTNAME
+        type: text
         default: ${auth.audit_name}
         constant: true
         required: true

--- a/host_vars/backup.yml
+++ b/host_vars/backup.yml
@@ -59,7 +59,7 @@ script_server_commands:
         constant: true
         required: true
 
-  - name: run-lastminute-windows
+  - name: run-windows_lastminute
     description: Runs windows_lastminute.yml
     group: ansible # for organization in script-server
     content: |

--- a/roles/icpc_host_backup/files/hosts.new
+++ b/roles/icpc_host_backup/files/hosts.new
@@ -523,6 +523,17 @@
 172.29.1.20  clock
 172.29.1.50  Sysops Printer?
 
+172.29.1.60 green-presclient0
+172.29.1.61 green-presclient1
+172.29.1.62 green-presclient2
+172.29.1.63 green-presclient3
+172.29.1.64 green-presclient4
+172.29.1.65 green-presclient5
+172.29.1.66 green-presclient6
+172.29.1.67 green-presclient7
+172.29.1.68 green-presclient8
+172.29.1.69 green-presclient9
+
 172.29.1.101         Netmon
 172.29.1.191    builder
 172.29.1.192    myicpc2

--- a/roles/icpc_host_backup/templates/iptables.rules.j2
+++ b/roles/icpc_host_backup/templates/iptables.rules.j2
@@ -82,10 +82,15 @@
 -A INPUT -p tcp --sport 80 -s 10.3.3.208 -j ACCEPT
 
 # script-server
+# blue
 -A INPUT -p tcp --dport 5000 -s 10.3.3.0/24 -j ACCEPT
 -A OUTPUT -p tcp --sport 5000 -d 10.3.3.0/24 -j ACCEPT
+# judges
 -A INPUT -p tcp --dport 5000 -s 10.2.2.0/24 -j ACCEPT
 -A OUTPUT -p tcp --sport 5000 -d 10.2.2.0/24 -j ACCEPT
+# green network (where some presentation clients live)
+-A INPUT -p tcp --dport 5000 -s 172.29.1.0/24 -j ACCEPT
+-A OUTPUT -p tcp --sport 5000 -d 172.29.1.0/24 -j ACCEPT
 
 # ntp in
 -A OUTPUT -p tcp --sport 123 -j ACCEPT

--- a/script/build_hosts
+++ b/script/build_hosts
@@ -262,6 +262,37 @@ windows:
         presclient7:
           ansible_host: 10.3.3.7
           presclient_name: "preclient7"
+
+        green-presclient0:
+          ansible_host: 172.29.1.60
+          presclient_name: green-presclient0
+        green-presclient1:
+          ansible_host: 172.29.1.61
+          presclient_name: green-presclient1
+        green-presclient2:
+          ansible_host: 172.29.1.62
+          presclient_name: green-presclient2
+        green-presclient3:
+          ansible_host: 172.29.1.63
+          presclient_name: green-presclient3
+        green-presclient4:
+          ansible_host: 172.29.1.64
+          presclient_name: green-presclient4
+        green-presclient5:
+          ansible_host: 172.29.1.65
+          presclient_name: green-presclient5
+        green-presclient6:
+          ansible_host: 172.29.1.66
+          presclient_name: green-presclient6
+        green-presclient7:
+          ansible_host: 172.29.1.67
+          presclient_name: green-presclient7
+        green-presclient8:
+          ansible_host: 172.29.1.68
+          presclient_name: green-presclient8
+        green-presclient9:
+          ansible_host: 172.29.1.69
+          presclient_name: green-presclient9
     win_balloonprinters:
       hosts:
         balloonmanager:


### PR DESCRIPTION
Add a script-server entry for windows_lastminute, and add some green presentation clients to the hosts file/build_hosts scripts. Also adjust firewall rules to allow green network access to script server.

If you don't want to run build_hosts, copy the changed content into the hosts.yml under `presentation_clients:`

I'm not sure if we actually want to let the script-server remain open on the green network in the firewall rules, might need to think on that/scope it down a bit more.


I also don't know what IP range we should actually be using for this. The IPs I used are apparently what Sam is using, but we did have another presclient section in the hosts.new file, we can change the IPs as needed, but this should be a good enough starting point.

I did not test any of this yet, but I think it should be approximately correct.