### PR TITLE
A whole pile of changes for Baku

### DIFF
--- a/action_plugins/github_release.py
+++ b/action_plugins/github_release.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python
+import re
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+from datetime import datetime
+from pathlib import Path
+from github import Github
+from requests_cache import DO_NOT_CACHE, get_cache, install_cache
+import requests
+
+display = Display()
+
+# Hook magic caching into github
+install_cache(
+    cache_control=True,
+    urls_expire_after={
+        '*.github.com': 360,  # Placeholder expiration; should be overridden by Cache-Control
+        '*': DO_NOT_CACHE,  # Don't cache anything other than GitHub requests
+    },
+    backend='filesystem',
+    cache_name='/root/ansible/.github_release_cache'
+)
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        super(ActionModule, self).run(tmp, task_vars)
+        self.version = self._task.args.get('version', 'latest')
+        self.repo = self._task.args.get('repo')
+        self.token = self._task.args.get('token', None)
+        self.cache = self._task.args.get('cache', True)
+        self.asset = self._task.args.get('asset')
+
+
+        ret = dict()
+        if not self.repo or not self.asset or not self.version:
+            ret['failed'] = True
+            ret['msg'] = "Missing required parameters"
+            return ret
+
+
+        gh = Github(self.token)
+        ghrepo = gh.get_repo(self.repo)
+        release = None
+
+        if self.version == 'latest':
+            release = ghrepo.get_latest_release()
+        elif self.version == 'latest-unreleased':
+            release = ghrepo.get_releases()[0]
+        else:
+            release = ghrepo.get_release(self.version)
+
+        for asset in release.get_assets():
+            if self.asset and not re.match(self.asset, asset.name):
+                continue
+
+            display.warning(f"Found matching asset: {asset.name}")
+            ret['version'] = release.tag_name
+            ret['asset'] = asset.name
+            ret['url'] = asset.browser_download_url
+            ret['size'] = asset.size
+            # ret['digest'] = asset.digest
+
+            # See if we already have this file
+            cache_path = Path(f'{task_vars['inventory_dir']}') / 'internet' / self.repo / asset.name
+            if self.cache:
+                cache_path.parent.mkdir(parents=True, exist_ok=True)
+                if cache_path.exists() and cache_path.stat().st_size == asset.size:
+                    ret['cached'] = True
+                    ret['cache_path'] = str(cache_path)
+                    break
+                else:
+                    display.warning(f"Cache miss for {asset.name}. Downloading to {cache_path}")
+
+            # Download the asset to a file
+            with cache_path.open('wb') as f:
+                f.write(requests.get(asset.browser_download_url).content)
+
+            # Also doesn't exist in the version we have via apt
+            # currently broken, see: https://github.com/PyGithub/PyGithub/issues/3315
+            # asset.download_asset(cache_path, chunk_size=8192)
+            ret['cache_path'] = str(cache_path)
+            break
+
+        if 'asset' not in ret:
+            ret['failed'] = True
+            ret['msg'] = f"No assets matched pattern: {self.asset}"
+            return ret
+
+        # Copy to remote system using proper action plugin file transfer
+        dest_path = self._task.args.get('dest')
+
+        # Transfer the file from controller to target
+        transferred_file = self._transfer_file(ret['cache_path'], dest_path)
+
+        # Use the copy module to handle final placement and permissions
+        module_args = {
+            'src': transferred_file,
+            'dest': dest_path,
+            'remote_src': True,  # File is now on the target machine
+        }
+        module_return = self._execute_module(module_name='copy',
+                                             module_args=module_args,
+                                             task_vars=task_vars, tmp=tmp)
+
+        # Merge ret and module_return
+        ret.update({k:v for k,v in module_return.items() if k in ('failed', 'changed', 'msg', 'dest')})
+
+        return ret
+
+
+# Structure:
+# Make api requests to find the release information
+# Fetch all assets for the release we are after
+# Match the assets against what we were asked to fetch (using regex)
+# Use the copy module to copy the asset from our cache to the host
+# Return the asset filename
+# Cache things in ./internet

--- a/action_plugins/github_release.py
+++ b/action_plugins/github_release.py
@@ -61,7 +61,7 @@ class ActionModule(ActionBase):
             # ret['digest'] = asset.digest
 
             # See if we already have this file
-            cache_path = Path(f'{task_vars['inventory_dir']}') / 'internet' / self.repo / asset.name
+            cache_path = Path(task_vars['inventory_dir']) / 'internet' / self.repo / asset.name
             if self.cache:
                 cache_path.parent.mkdir(parents=True, exist_ok=True)
                 if cache_path.exists() and cache_path.stat().st_size == asset.size:

--- a/host_vars/backup.yml
+++ b/host_vars/backup.yml
@@ -47,7 +47,7 @@ script_server_commands:
     content: |
       #!/usr/bin/bash -ex
       cd /root/ansible
-      fast-ansible-playbook --limit "$PARAM_HOSTNAME" lastminute.yml
+      ansible-playbook --limit "$PARAM_HOSTNAME" lastminute.yml
     parameters:
       - name: hostname
         env_var: PARAM_HOSTNAME
@@ -66,7 +66,7 @@ script_server_commands:
     content: |
       #!/usr/bin/bash -ex
       cd /root/ansible
-      fast-ansible-playbook --limit "$PARAM_HOSTNAME" windows_lastminute.yml
+      ansible-playbook --limit "$PARAM_HOSTNAME" windows_lastminute.yml
     parameters:
       - name: hostname
         env_var: PARAM_HOSTNAME
@@ -228,7 +228,7 @@ script_server_commands:
     content: |
       #!/usr/bin/bash -ex
       cd /root/ansible
-      fast-ansible-playbook --limit "$HOST_PATTERN" windows_lastminute.yml
+      ansible-playbook --limit "$HOST_PATTERN" windows_lastminute.yml
     parameters:
       - name: host_pattern
         env_var: HOST_PATTERN # default is same as name
@@ -254,9 +254,9 @@ script_server_commands:
     content: |
       #!/usr/bin/bash -ex
       cd /root/ansible
-      fast-ansible -m ansible.windows.win_shell -a 'stop-process -name "java" -force' $HOST_PATTERN
-      fast-ansible -m ansible.windows.win_shell -a "rm -force -r c:/users/icpc/appdata/local/temp/org.icpc*" $HOST_PATTERN
-      fast-ansible -m ansible.windows.win_reboot $HOST_PATTERN
+      ansible -m ansible.windows.win_shell -a 'stop-process -name "java" -force' $HOST_PATTERN
+      ansible -m ansible.windows.win_shell -a "rm -force -r c:/users/icpc/appdata/local/temp/org.icpc*" $HOST_PATTERN
+      ansible -m ansible.windows.win_reboot $HOST_PATTERN
     parameters:
       - name: host_pattern
         env_var: HOST_PATTERN # default is same as name
@@ -282,7 +282,7 @@ script_server_commands:
     content: |
       #!/usr/bin/bash -ex
       cd /root/ansible
-      fast-ansible-playbook --limit "$HOST_PATTERN" lastminute.yml
+      ansible-playbook --limit "$HOST_PATTERN" lastminute.yml
     parameters:
       - name: host_pattern
         env_var: HOST_PATTERN # default is same as name
@@ -303,7 +303,7 @@ script_server_commands:
     content: |
       #!/usr/bin/bash -ex
       cd /root/ansible
-      fast-ansible-playbook --limit "$HOST_PATTERN" lastminute.yml
+      ansible-playbook --limit "$HOST_PATTERN" lastminute.yml
     parameters:
       - name: host_pattern
         env_var: HOST_PATTERN # default is same as name
@@ -345,7 +345,7 @@ script_server_commands:
     content: |
       #!/usr/bin/bash -ex
       cd /root/ansible
-      fast-ansible-playbook --limit "$HOST_PATTERN" lastminute.yml
+      ansible-playbook --limit "$HOST_PATTERN" lastminute.yml
     parameters:
       - name: host_pattern
         env_var: HOST_PATTERN # default is same as name

--- a/host_vars/cds.yml
+++ b/host_vars/cds.yml
@@ -1,5 +1,8 @@
 ---
-# extra_nic_configs: []
+extra_nic_configs: []
+cds_version: latest-unreleased
+cds_contest_git_repo: git@packages:wf49baku.git
+
 ccs_url: &ccs_url https://domjudge/api/contests/wf48_systest2
 ccs_user: &ccs_user cds
 ccs_pass: &ccs_pass physicist-five-miracles

--- a/lastminute.yml
+++ b/lastminute.yml
@@ -1,9 +1,61 @@
 ---
+- name: Configure backup server
+  hosts: backup
+  strategy: linear # we want this complete before we do any other hosts
+  roles:
+    - role: dnsmasq
+      tags: dnsmasq
+    - role: icpc_host_backup
+      tags: icpc_host_backup
+    # script_server needs to come after the hosts file has been configured (because it needs to lookup some hostnames)
+    - role: script_server
+      tags: script_server
+  tasks:
+    - name: Configure backup as ssh ca server
+      ansible.builtin.include_role:
+        name: ssh_ca
+        tasks_from: ca
+      tags: ssh_ca
+
 - name: Configure packages machines
   hosts: packages
   roles:
     - role: icpc_host_packages
       tags: icpc_host_packages
+
+- name: SSH CA Certs
+  hosts: all,!contestants
+  gather_facts: true # We need facts so we can limit the user certs to the ip of the host they're tied to
+  tags: ssh_ca
+  tasks:
+    - name: Configure host ssh keys and trust user CA
+      ansible.builtin.include_role:
+        name: ssh_ca
+
+    # Every host gets an icpc@hostname ssh certificate, and hosts allow those keys to log in by adding the names to
+    # ~/.ssh/authorized_principals. E.g. if you add icpc@cds to the file, then the icpc user on the cds has a key that will allow it to log in.
+    # A more practical example might be for the ccsadmins to all be allowed to log into the ccs server, or judgehosts, etc. So they don't have
+    # to distribute their own keys to every machine manually.
+    - name: Make sure the .ssh directory exists
+      ansible.builtin.file:
+        path: /home/icpc/.ssh
+        state: directory
+        mode: "0700"
+        owner: icpc
+        group: icpc
+    - name: Ensure id_ed25519 key for icpc@icpc
+      community.crypto.openssh_keypair:
+        path: /home/icpc/.ssh/id_ed25519
+        type: ed25519
+        owner: icpc
+        group: icpc
+    - name: Generate ssh cert for the key we just made
+      ansible.builtin.include_role:
+        name: ssh_ca
+        tasks_from: user
+      vars:
+        ssh_key_to_sign: /home/icpc/.ssh/id_ed25519.pub
+        ssh_principal: "icpc@{{ inventory_hostname }}"
 
 # this needs to be first as ldap requires it
 - name: Pre-configure apt
@@ -30,17 +82,6 @@
   roles:
     - role: scoreboard
       tags: scoreboard
-
-- name: Configure backups
-  hosts: backup*
-  roles:
-    - role: dnsmasq
-      tags: dnsmasq
-    - role: icpc_host_backup
-      tags: icpc_host_backup
-    # script_server needs to come after the hosts file has been configured (because it needs to lookup some hostnames)
-    - role: script_server
-      tags: script_server
 
 - name: Configure extra_nic machines
   hosts: backup, scoreboard, printsrv, cds, packages

--- a/lastminute.yml
+++ b/lastminute.yml
@@ -12,13 +12,6 @@
     - role: apt
       tags: apt
   tasks:
-    - name: Fix permissioning of intermediate cert
-      tags: fix_cert  # TODO this should be fixed in icpc2025
-      ansible.builtin.file:
-        path: /usr/share/ca-certificates/ICPC_WF_Intermediate_CA.crt
-        mode: "0644"
-      notify: Run update-ca-certificates
-
     - name: Fix LC_TIME
       ansible.builtin.lineinfile:
         path: /etc/default/locale
@@ -31,19 +24,6 @@
         regexp: ^LC_PAPER
         line: LC_PAPER="en_US.UTF-8"
       tags: fix_LC_PAPER
-    - name: Fix Root cert
-      ansible.builtin.copy:
-        src: /usr/share/ca-certificates/ICPC_WF_Root_CA.crt
-        dest: /usr/share/ca-certificates/ICPC_WF_Root_CA.crt
-        mode: "0644"
-      tags: fix_root  # TODO this should fixed in icpc2025
-      notify: Run update-ca-certificates
-  handlers:
-    - name: Run update-ca-certificates
-      ansible.builtin.command: /usr/sbin/update-ca-certificates
-      register: my_output  # <- Registers the command output.
-      changed_when: my_output.rc != 0  # <- Uses the return code to define when the task has changed.
-
 
 - name: Configure scoreboard machine
   hosts: packages,scoreboard
@@ -593,6 +573,8 @@
       ansible.builtin.shell: >
         set -o pipefail &&
         echo "Provisioned at $(date +"%Y-%m-%d %H:%M:%S")\nRevision: $(git rev-list --full-history --all --abbrev-commit | head -1)\n"
+      args:
+        executable: /bin/bash # needed for pipefail
       become: false
       register: git_revision
       delegate_to: 127.0.0.1

--- a/lastminute.yml
+++ b/lastminute.yml
@@ -243,7 +243,7 @@
       loop:
         - "icpc"
         - "team"
-      when: root_password is defined
+      when: root_password is defined and root_password is not none
 
     - name: Workaround nautilus auto-mounting
       ansible.builtin.file:
@@ -456,7 +456,7 @@
         state: present
         password: "{{ root_password }}"
       when:
-        - root_password is defined
+        - root_password is defined and root_password is not none
         - '"$6$" in root_password'
       tags: do_root_passwd
 
@@ -466,7 +466,7 @@
         state: present
         password: "{{ root_password | password_hash('sha512', root_password) }}"
       when:
-        - root_password is defined
+        - root_password is defined and root_password is not none
         - '"$6$" not in root_password'
 
     - name: Get GIT revision

--- a/lastminute.yml
+++ b/lastminute.yml
@@ -57,9 +57,12 @@
         ssh_key_to_sign: /home/icpc/.ssh/id_ed25519.pub
         ssh_principal: "icpc@{{ inventory_hostname }}"
 
-# this needs to be first as ldap requires it
 - name: Pre-configure apt
   hosts: all
+  pre_tasks:
+    - name: Run update-ca-certificates # TODO: fix upstream, for some reason this didn't get run on the image
+      ansible.builtin.command: update-ca-certificates
+      changed_when: false
   roles:
     - role: apt
       tags: apt

--- a/library/github_release.py
+++ b/library/github_release.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+from datetime import datetime
+import urllib.request
+import urllib.error
+import json
+
+DOCUMENTATION = r'''
+---
+module: github_release
+
+short_description: Fetches and caches a GitHub release asset
+version_added: "1.0.0"
+
+description:
+    - Downloads GitHub release assets and caches them locally
+    - Supports pattern matching for asset names using regex
+    - Automatically copies the asset to the target destination
+
+options:
+    repo:
+        description: GitHub repository in format 'owner/repo'
+        required: true
+        type: str
+    version:
+        description:
+            - Version of the release to fetch
+            - Use 'latest' for the latest stable release
+            - Use 'latest-unreleased' for the most recent release (including pre-releases)
+            - Use specific version tag (e.g. 'v1.0.0')
+        required: false
+        type: str
+        default: latest
+    asset:
+        description:
+            - Regex pattern to match asset names
+            - First matching asset will be downloaded
+        required: true
+        type: str
+    dest:
+        description: Destination path on the target host
+        required: true
+        type: str
+    cache:
+        description: Whether to cache downloaded assets locally
+        required: false
+        type: bool
+        default: true
+    token:
+        description: GitHub personal access token for authentication
+        required: false
+        type: str
+
+author:
+    - ICPC Systems Operations
+'''
+
+EXAMPLES = r'''
+# Download latest CDS release asset
+- name: Fetch latest CDS
+  github_release:
+    repo: icpctools/icpctools
+    asset: ".*wlp.*"
+    version: latest
+    dest: /tmp/cds.zip
+
+# Download specific version
+- name: Fetch specific CDS version
+  github_release:
+    repo: icpctools/icpctools
+    version: v2.5.1082
+    asset: "wlp.CDS-.*\\.zip"
+    dest: /tmp/wlp.CDS-2.5.1082.zip
+
+# Download with authentication token
+- name: Fetch from private repo
+  github_release:
+    repo: myorg/private-repo
+    asset: "release-.*\\.tar\\.gz"
+    version: latest
+    dest: /opt/app/release.tar.gz
+    token: "{{ github_token }}"
+    cache: false
+'''
+
+RETURN = r'''
+asset:
+    description: Name of the downloaded asset file
+    type: str
+    returned: success
+    sample: 'wlp.CDS-2.5.1082.zip'
+version:
+    description: Version tag of the release
+    type: str
+    returned: success
+    sample: 'v2.5.1082'
+url:
+    description: Download URL of the asset
+    type: str
+    returned: success
+    sample: 'https://github.com/icpctools/icpctools/releases/download/v2.5.1082/wlp.CDS-2.5.1082.zip'
+size:
+    description: Size of the asset in bytes
+    type: int
+    returned: success
+    sample: 72366764
+cache_path:
+    description: Local cache path where the asset is stored
+    type: str
+    returned: success
+    sample: '/mnt/ansible/internet/icpctools/icpctools/wlp.CDS-2.5.1082.zip'
+cached:
+    description: Whether the asset was already cached (not downloaded)
+    type: bool
+    returned: success
+    sample: true
+dest:
+    description: Destination path on the target host
+    type: str
+    returned: success
+    sample: '/tmp/foo2'
+changed:
+    description: Whether the target file was changed
+    type: bool
+    returned: always
+    sample: false
+failed:
+    description: Whether the operation failed
+    type: bool
+    returned: failure
+    sample: false
+msg:
+    description: Error message if operation failed
+    type: str
+    returned: failure
+    sample: 'No assets matched pattern: .*nonexistent.*'
+'''

--- a/roles/cds/tasks/cds_instance.yml
+++ b/roles/cds/tasks/cds_instance.yml
@@ -94,6 +94,43 @@
     mode: '0600'
   register: cds_config_updated
 
+- name: Populate server.env for sentry dsn
+  ansible.builtin.copy:
+    content: |
+      #SENTRY_DSN="https://fill_with_sentry_dsn@replace.sentry.io/identifier"
+    dest: /srv/cds/wlp/usr/servers/{{ cds_instance_name }}/server.env
+    owner: cds
+    group: cds
+    mode: '0644'
+- name: Populate sentry.properties
+  ansible.builtin.copy:
+    content: |
+      #dsn=https://fill_with_sentry_dsn@replace.sentry.io/identifier"
+      # Add data like request headers and IP for users,
+      # see https://docs.sentry.io/platforms/java/data-management/data-collected/ for more info
+      send-default-pii=false
+    dest: /srv/cds/wlp/usr/servers/{{ cds_instance_name }}/sentry.properties
+    owner: cds
+    group: cds
+    mode: '0644'
+- name: Make sure jvm options file exists with proper content
+  ansible.builtin.copy:
+    content: |
+      -DICPC_OGG=false
+    dest: /srv/cds/wlp/usr/servers/{{ cds_instance_name }}/jvm.options
+    owner: cds
+    group: cds
+    mode: '0644'
+
+- name: Check if presentations are a symlink
+  ansible.builtin.stat:
+    path: /srv/cds/wlp/usr/servers/{{ cds_instance_name }}/config/present
+  register: presentations_stat
+- name: Delete presentations directory so we can make it a symlink
+  ansible.builtin.file:
+    path: /srv/cds/wlp/usr/servers/{{ cds_instance_name }}/config/present
+    state: absent
+  when: presentations_stat.stat.isdir | default(false)
 - name: Symlink presentations to the config directory
   ansible.builtin.file:
     state: link

--- a/roles/cds/tasks/main.yml
+++ b/roles/cds/tasks/main.yml
@@ -28,15 +28,6 @@
     owner: cds
     group: cds
 
-- name: Disable strict host key checking for the cds user
-  ansible.builtin.copy:
-    content: |
-      Host *
-        StrictHostKeyChecking no
-    dest: /srv/cds/.ssh/config
-    owner: cds
-    group: cds
-    mode: "0644"
 
 - name: Create CDS directories
   ansible.builtin.file:

--- a/roles/cds/tasks/main.yml
+++ b/roles/cds/tasks/main.yml
@@ -89,7 +89,7 @@
     version: "{{ cds_version }}"
     dest: /srv/cds/CDS.zip
   register: cds_zip_download
-- name: Download and unpack CDS war to /srv/cdspackage
+- name: Download and unpack CDS war to /srv/cdspackage # noqa: command-instead-of-module no-changed-when
   ansible.builtin.shell: >
     unzip -jo /srv/cds/CDS.zip '*/CDS.war' -d /srv/cds/
   when: cds_zip_download.changed or not cds_war.stat.exists

--- a/roles/cds/tasks/main.yml
+++ b/roles/cds/tasks/main.yml
@@ -50,92 +50,44 @@
     - /var/lib/cds
 
 
-# Get the cds_version from github if the version specified is 'latest'
-- name: Get the CDS release
-  delegate_to: localhost
-  ansible.builtin.uri:
-    url: https://api.github.com/repos/icpctools/icpctools/releases?per_page=1
-    headers: "{{ github_headers }}"
-    method: GET
-    return_content: true
-    status_code: 200
-    body_format: json
-  register: latest_cds_release_array
-  check_mode: false
-  when: cds_version == "latest"
-- name: Set CDS latest version
-  ansible.builtin.set_fact:
-    cds_version: "{{ latest_cds_release_array.json[0].name | replace('v', '') }}"
-  when: cds_version == "latest"
-- name: Set CDS minor version
-  ansible.builtin.set_fact:
-    cds_version_minor: "{{ cds_version | regex_replace('\\.\\d+$', '') }}"
-
-- name: Check and download the files locally if we don't have them
-  block:
-    - name: Check if we have wlp.CDS.zip
-      delegate_to: localhost
-      ansible.builtin.stat:
-        path: "{{ lookup('ansible.builtin.fileglob', 'wlp.CDS-' + cds_version + '.zip', wantlist=True) | sort | last }}"
-      register: wlp_cds_zip_present
-      ignore_errors: true
-    - name: Download wlp.CDS.zip
-      delegate_to: localhost
-      ansible.builtin.get_url:
-        url: https://github.com/icpctools/icpctools/releases/download/v{{ cds_version }}/wlp.CDS-{{ cds_version }}.zip
-        dest: "{{ inventory_dir }}/files/wlp.CDS-{{ cds_version }}.zip"
-        mode: "0644"
-      when: wlp_cds_zip_present.failed
-
-    - name: Check if we have CDS.zip
-      delegate_to: localhost
-      ansible.builtin.stat:
-        path: "{{ lookup('ansible.builtin.fileglob', 'CDS-' + cds_version + '.zip', wantlist=True) | sort | last }}"
-      register: cds_zip_present
-      ignore_errors: true
-    - name: Download CDS.zip
-      delegate_to: localhost
-      ansible.builtin.get_url:
-        url: https://github.com/icpctools/icpctools/releases/download/v{{ cds_version }}/CDS-{{ cds_version }}.zip
-        dest: "{{ inventory_dir }}/files/CDS-{{ cds_version }}.zip"
-        mode: "0644"
-      when: cds_zip_present.failed
-
-
 - name: Check if wlp.CDS is installed
   ansible.builtin.stat:
     path: /srv/cds/wlp/usr/servers
   register: wlp_cds_pkg_installed
   check_mode: false
 
+- name: Download wlp.CDS
+  github_release:
+    repo: icpctools/icpctools
+    asset: "^wlp.CDS-.*\\.zip$"
+    version: "{{ cds_version }}"
+    dest: /srv/cds/wlp.CDS.zip
+  when: not wlp_cds_pkg_installed.stat.exists
+
 - name: Download and unpack full CDS if it doesn't exist
   ansible.builtin.unarchive:
-    src: files/wlp.CDS-{{ cds_version }}.zip
+    src: /srv/cds/wlp.CDS.zip
+    remote_src: true
     dest: /srv/cds
     owner: cds
     group: cds
   when: not wlp_cds_pkg_installed.stat.exists
 
-- name: Create a directory for this version of the CDS.war
-  ansible.builtin.file:
-    state: directory
-    path: /srv/cdspackages/{{ cds_version }}
-    mode: "0755"
-- name: Download and unpack CDS war to /srv/cdspackages
-  ansible.builtin.unarchive:
-    src: files/CDS-{{ cds_version }}.zip
-    dest: /srv/cdspackages/{{ cds_version }}
-    creates: /srv/cdspackages/{{ cds_version }}/CDS-{{ cds_version_minor }}/CDS.war
-    owner: cds
-    group: cds
-    mode: "0644"
-
-- name: Make sure /srv/cds/CDS.war is a symlink to the correct cds version
-  ansible.builtin.file:
-    src: /srv/cdspackages/{{ cds_version }}/CDS-{{ cds_version_minor }}/CDS.war
-    dest: /srv/cds/CDS.war
-    state: link
-    force: true
+- name: Check if cds.war exists
+  ansible.builtin.stat:
+    path: /srv/cds/CDS.war
+  register: cds_war
+- name: Download CDS itself
+  github_release:
+    repo: icpctools/icpctools
+    asset: "^CDS-.*\\.zip$"
+    version: "{{ cds_version }}"
+    dest: /srv/cds/CDS.zip
+  register: cds_zip_download
+- name: Download and unpack CDS war to /srv/cdspackage
+  ansible.builtin.shell: >
+    unzip -jo /srv/cds/CDS.zip '*/CDS.war' -d /srv/cds/
+  when: cds_zip_download.changed or not cds_war.stat.exists
   register: updated_war
 
 - name: Make sure the cds directory exists

--- a/roles/cds/tasks/main.yml
+++ b/roles/cds/tasks/main.yml
@@ -28,6 +28,13 @@
     owner: cds
     group: cds
 
+- name: Generate ssh cert for the key we just made
+  ansible.builtin.include_role:
+    name: ssh_ca
+    tasks_from: user
+  vars:
+    ssh_key_to_sign: /srv/cds/.ssh/id_ed25519.pub
+    ssh_principal: "cds@{{ inventory_hostname }}"
 
 - name: Disable nginx because the cds runs on those ports
   ansible.builtin.systemd:

--- a/roles/cds/tasks/main.yml
+++ b/roles/cds/tasks/main.yml
@@ -29,6 +29,13 @@
     group: cds
 
 
+- name: Disable nginx because the cds runs on those ports
+  ansible.builtin.systemd:
+    name: nginx
+    state: stopped
+    enabled: false
+    masked: true
+
 - name: Create CDS directories
   ansible.builtin.file:
     path: "{{ item }}"

--- a/roles/gitserver/defaults/main.yml
+++ b/roles/gitserver/defaults/main.yml
@@ -1,3 +1,12 @@
 # array of local keys to add
 local_ssh_keys: []
 git_user_password: WFltGBxB/v4Fs
+
+gitserver_repos: []
+#   - name: ansible
+#     remote: git@github.com:icpcsysops/ansible
+#     deploy_key: /root/.ssh/ansible-deploykey
+
+#   - name: wf49baku
+#     remote: git@github.com:icpcsysops/wf49baku
+#     deploy_key: /root/.ssh/wf49baku-deploykey

--- a/roles/gitserver/tasks/main.yml
+++ b/roles/gitserver/tasks/main.yml
@@ -66,3 +66,38 @@
     state: touch
     modification_time: preserve
     access_time: preserve
+
+
+# Clone a set of repositories and make them available
+- name: Create key files
+  ansible.builtin.copy:
+    dest: "{{ git_home_dir }}/.ssh/git-privatekey-{{ item.name }}"
+    owner: git
+    group: git
+    mode: "0600"
+    content: "{{ lookup('file', item.deploy_key) }}\n"
+  no_log: true
+  diff: false
+  loop: "{{ gitserver_repos }}"
+
+- name: Clone/update repositories
+  ansible.builtin.git:
+    repo: "{{ item.remote }}"
+    dest: "{{ git_home_dir }}/{{ item.name }}.git"
+    version: master
+    bare: true
+    key_file: "{{ git_home_dir }}/.ssh/git-privatekey-{{ item.name }}"
+    accept_newhostkey: true # does trust-on-first-use
+  become: true
+  become_user: git
+  loop: "{{ gitserver_repos }}"
+
+- name: Configure the key properly in the repo for manual commands
+  community.general.git_config:
+    name: core.sshCommand
+    value: "ssh -i ~/.ssh/git-privatekey-{{ item.name }}"
+    scope: "local"
+    repo: "{{ git_home_dir }}/{{ item.name }}.git"
+  become: true
+  become_user: git
+  loop: "{{ gitserver_repos }}"

--- a/roles/gitserver/tasks/main.yml
+++ b/roles/gitserver/tasks/main.yml
@@ -57,6 +57,14 @@
     group: git
     mode: "0600"
 
+- name: Set up some authorized_principals for git user
+  ansible.builtin.template:
+    src: authorized_principals.j2
+    dest: "{{ git_home_dir }}/.ssh/authorized_principals"
+    owner: git
+    group: git
+    mode: "0600"
+
 - name: Make git user hushlogin
   ansible.builtin.file:
     path: "{{ git_home_dir }}/.hushlogin"

--- a/roles/gitserver/templates/authorized_principals.j2
+++ b/roles/gitserver/templates/authorized_principals.j2
@@ -1,0 +1,24 @@
+# CDS (most important)
+cds@cds
+icpc@cds
+# Servers/Admins
+icpc@backup
+icpc@packages
+icpc@troy-mgmt
+icpc@keith-mgmt
+# DOMjudge machines
+icpc@domjudge-1
+icpc@domjudge-2
+icpc@domjudge-ccsadmin1
+icpc@domjudge-ccsadmin2
+icpc@domjudge-ccsadmin3
+icpc@domjudge-ccsadmin4
+# PC2 Machines
+icpc@pc2
+icpc@pc2backup
+icpc@pc2-ccsadmin1
+icpc@pc2-ccsadmin2
+icpc@pc2-ccsadmin3
+icpc@pc2-ccsadmin4
+
+# TODO: can we use inventory_hostnames or more jinja magic to make this more dynamic?

--- a/roles/icpc_host_backup/files/hosts.new
+++ b/roles/icpc_host_backup/files/hosts.new
@@ -1,107 +1,112 @@
-127.0.0.1	localhost
-127.0.1.1    firefox.settings.services.mozilla.com
+127.0.0.1    localhost
 
-10.1.0.253      fog-server
+#############################################
+# WF Team Network - VLAN 10	                #
+# 10.1.1.0/23                               #
+# GW - 10.1.1.254                           #
+#############################################
+# Team Network (10.1.1.0/23)
+#Imaging 10.1.0.1-254 - DHCP only when needed
 
-10.1.1.1  	team1
-10.1.1.2  	team2
-10.1.1.3  	team3
-10.1.1.4  	team4
-10.1.1.5  	team5
-10.1.1.6  	team6
-10.1.1.7  	team7
-10.1.1.8  	team8
-10.1.1.9  	team9
-10.1.1.10 	team10
-10.1.1.11 	team11
-10.1.1.12 	team12
-10.1.1.13 	team13
-10.1.1.14 	team14
-10.1.1.15 	team15
-10.1.1.16 	team16
-10.1.1.17 	team17
-10.1.1.18 	team18
-10.1.1.19 	team19
-10.1.1.20 	team20
-10.1.1.21 	team21
-10.1.1.22 	team22
-10.1.1.23 	team23
-10.1.1.24 	team24
-10.1.1.25 	team25
-10.1.1.26 	team26
-10.1.1.27 	team27
-10.1.1.28 	team28
-10.1.1.29 	team29
-10.1.1.30 	team30
-10.1.1.31 	team31
-10.1.1.32 	team32
-10.1.1.33 	team33
-10.1.1.34 	team34
-10.1.1.35 	team35
-10.1.1.36 	team36
-10.1.1.37 	team37
-10.1.1.38 	team38
-10.1.1.39 	team39
-10.1.1.40 	team40
-10.1.1.41 	team41
-10.1.1.42 	team42
-10.1.1.43 	team43
-10.1.1.44 	team44
-10.1.1.45 	team45
-10.1.1.46 	team46
-10.1.1.47 	team47
-10.1.1.48 	team48
-10.1.1.49 	team49
-10.1.1.50 	team50
-10.1.1.51 	team51
-10.1.1.52 	team52
-10.1.1.53 	team53
-10.1.1.54 	team54
-10.1.1.55 	team55
-10.1.1.56 	team56
-10.1.1.57 	team57
-10.1.1.58 	team58
-10.1.1.59 	team59
-10.1.1.60 	team60
-10.1.1.61 	team61
-10.1.1.62 	team62
-10.1.1.63 	team63
-10.1.1.64 	team64
-10.1.1.65 	team65
-10.1.1.66 	team66
-10.1.1.67 	team67
-10.1.1.68 	team68
-10.1.1.69 	team69
-10.1.1.70 	team70
-10.1.1.71 	team71
-10.1.1.72 	team72
-10.1.1.73 	team73
-10.1.1.74 	team74
-10.1.1.75 	team75
-10.1.1.76 	team76
-10.1.1.77 	team77
-10.1.1.78 	team78
-10.1.1.79 	team79
-10.1.1.80 	team80
-10.1.1.81 	team81
-10.1.1.82 	team82
-10.1.1.83 	team83
-10.1.1.84 	team84
-10.1.1.85 	team85
-10.1.1.86 	team86
-10.1.1.87 	team87
-10.1.1.88 	team88
-10.1.1.89 	team89
-10.1.1.90 	team90
-10.1.1.91 	team91
-10.1.1.92 	team92
-10.1.1.93 	team93
-10.1.1.94 	team94
-10.1.1.95 	team95
-10.1.1.96 	team96
-10.1.1.97 	team97
-10.1.1.98 	team98
-10.1.1.99 	team99
+10.1.1.1	team1
+10.1.1.2	team2
+10.1.1.3	team3
+10.1.1.4	team4
+10.1.1.5	team5
+10.1.1.6	team6
+10.1.1.7	team7
+10.1.1.8	team8
+10.1.1.9	team9
+10.1.1.10	team10
+10.1.1.11	team11
+10.1.1.12	team12
+10.1.1.13	team13
+10.1.1.14	team14
+10.1.1.15	team15
+10.1.1.16	team16
+10.1.1.17	team17
+10.1.1.18	team18
+10.1.1.19	team19
+10.1.1.20	team20
+10.1.1.21	team21
+10.1.1.22	team22
+10.1.1.23	team23
+10.1.1.24	team24
+10.1.1.25	team25
+10.1.1.26	team26
+10.1.1.27	team27
+10.1.1.28	team28
+10.1.1.29	team29
+10.1.1.30	team30
+10.1.1.31	team31
+10.1.1.32	team32
+10.1.1.33	team33
+10.1.1.34	team34
+10.1.1.35	team35
+10.1.1.36	team36
+10.1.1.37	team37
+10.1.1.38	team38
+10.1.1.39	team39
+10.1.1.40	team40
+10.1.1.41	team41
+10.1.1.42	team42
+10.1.1.43	team43
+10.1.1.44	team44
+10.1.1.45	team45
+10.1.1.46	team46
+10.1.1.47	team47
+10.1.1.48	team48
+10.1.1.49	team49
+10.1.1.50	team50
+10.1.1.51	team51
+10.1.1.52	team52
+10.1.1.53	team53
+10.1.1.54	team54
+10.1.1.55	team55
+10.1.1.56	team56
+10.1.1.57	team57
+10.1.1.58	team58
+10.1.1.59	team59
+10.1.1.60	team60
+10.1.1.61	team61
+10.1.1.62	team62
+10.1.1.63	team63
+10.1.1.64	team64
+10.1.1.65	team65
+10.1.1.66	team66
+10.1.1.67	team67
+10.1.1.68	team68
+10.1.1.69	team69
+10.1.1.70	team70
+10.1.1.71	team71
+10.1.1.72	team72
+10.1.1.73	team73
+10.1.1.74	team74
+10.1.1.75	team75
+10.1.1.76	team76
+10.1.1.77	team77
+10.1.1.78	team78
+10.1.1.79	team79
+10.1.1.80	team80
+10.1.1.81	team81
+10.1.1.82	team82
+10.1.1.83	team83
+10.1.1.84	team84
+10.1.1.85	team85
+10.1.1.86	team86
+10.1.1.87	team87
+10.1.1.88	team88
+10.1.1.89	team89
+10.1.1.90	team90
+10.1.1.91	team91
+10.1.1.92	team92
+10.1.1.93	team93
+10.1.1.94	team94
+10.1.1.95	team95
+10.1.1.96	team96
+10.1.1.97	team97
+10.1.1.98	team98
+10.1.1.99	team99
 10.1.1.100	team100
 10.1.1.101	team101
 10.1.1.102	team102
@@ -184,406 +189,474 @@
 10.1.1.179	team179
 10.1.1.180	team180
 
-10.1.1.254	gateway1
+10.1.1.254    team-gateway
 
-#Judge Network (10.2.2.0/24)
-# Human judges 10.2.2.0/27
-10.2.2.1      judge1
-10.2.2.2      judge2
-10.2.2.3      judge3
-10.2.2.4      judge4
-10.2.2.5      judge5
-10.2.2.6      judge6
-10.2.2.7      judge7
-10.2.2.8      judge8
-10.2.2.9      judge9
-10.2.2.10     judge10
-10.2.2.11     judge11
-10.2.2.12     judge12
-10.2.2.13     judge13
-10.2.2.14     judge14
-10.2.2.15     judge15
-10.2.2.16     judge16
-10.2.2.17     judge17
-10.2.2.18     judge18
-10.2.2.19     judge19
-10.2.2.20     judge20
-10.2.2.21     judge21
-10.2.2.22     judge22
-10.2.2.23     judge23
-10.2.2.24     judge24
-10.2.2.25     judge25
-10.2.2.26     judge26
-10.2.2.27     judge27
-10.2.2.28     judge28
-10.2.2.29     judge29
-10.2.2.30     judge30
-10.2.2.31     judge31
-# Kattis AutoJudges  10.2.2.32/27
-10.2.2.32    autojudge1
-10.2.2.33    autojudge2
-10.2.2.34    autojudge3
-10.2.2.35    autojudge4
-10.2.2.36    autojudge5
-10.2.2.37    autojudge6
-10.2.2.38    autojudge7
-10.2.2.39    autojudge8
-10.2.2.40    autojudge9
-10.2.2.41    autojudge10
-10.2.2.42    autojudge11
-10.2.2.43    autojudge12
-10.2.2.44    autojudge13
-10.2.2.45    autojudge14
-10.2.2.46    autojudge15
-10.2.2.47    autojudge16
-10.2.2.48    autojudge17
-10.2.2.49    autojudge18
-10.2.2.50    autojudge19
-10.2.2.51    autojudge20
-10.2.2.52    autojudge21
-10.2.2.53    autojudge22
-10.2.2.54    autojudge23
-10.2.2.55    autojudge24
-10.2.2.56    autojudge25
-10.2.2.57    autojudge26
-10.2.2.58    autojudge27
-10.2.2.59    autojudge28
-10.2.2.60    autojudge29
-10.2.2.61    autojudge30
-10.2.2.62    autojudge31
-10.2.2.63    autojudge32
-# pc2 aj 10.2.2.128/27
-10.2.2.128    pc2-aj1
-10.2.2.129    pc2-aj2
-10.2.2.130    pc2-aj3
-10.2.2.131    pc2-aj4
-10.2.2.132    pc2-aj5
-10.2.2.133    pc2-aj6
-10.2.2.134    pc2-aj7
-10.2.2.135    pc2-aj8
-10.2.2.136    pc2-aj9
-10.2.2.137    pc2-aj10
-10.2.2.138    pc2-aj11
-10.2.2.139    pc2-aj12
-10.2.2.140    pc2-aj13
-10.2.2.141    pc2-aj14
-10.2.2.142    pc2-aj15
-10.2.2.143    pc2-aj16
-10.2.2.144    pc2-aj17
-10.2.2.145    pc2-aj18
-10.2.2.146    pc2-aj19
-10.2.2.147    pc2-aj20
-10.2.2.148    pc2-aj21
-10.2.2.149    pc2-aj22
-10.2.2.150    pc2-aj23
-10.2.2.151    pc2-aj24
-10.2.2.152    pc2-aj25
-10.2.2.153    pc2-aj26
-10.2.2.154    pc2-aj27
-10.2.2.155    pc2-aj28
-10.2.2.156    pc2-aj29
-10.2.2.157    pc2-aj30
-10.2.2.158    pc2-aj31
-10.2.2.159    pc2-aj32
-# domjudge judgehosts 10.2.2.192/27
-10.2.2.192    domjudge-judgehost1
-10.2.2.193    domjudge-judgehost2
-10.2.2.194    domjudge-judgehost3
-10.2.2.195    domjudge-judgehost4
-10.2.2.196    domjudge-judgehost5
-10.2.2.197    domjudge-judgehost6
-10.2.2.198    domjudge-judgehost7
-10.2.2.199    domjudge-judgehost8
-10.2.2.200    domjudge-judgehost9
-10.2.2.201    domjudge-judgehost10
-10.2.2.202    domjudge-judgehost11
-10.2.2.203    domjudge-judgehost12
-10.2.2.204    domjudge-judgehost13
-10.2.2.205    domjudge-judgehost14
-10.2.2.206    domjudge-judgehost15
-10.2.2.207    domjudge-judgehost16
-10.2.2.208    domjudge-judgehost17
-10.2.2.209    domjudge-judgehost18
-10.2.2.210    domjudge-judgehost19
-10.2.2.211    domjudge-judgehost20
-10.2.2.212    domjudge-judgehost21
-10.2.2.213    domjudge-judgehost22
-10.2.2.214    domjudge-judgehost23
-10.2.2.215    domjudge-judgehost24
-10.2.2.216    domjudge-judgehost25
-10.2.2.217    domjudge-judgehost26
-10.2.2.218    domjudge-judgehost27
-10.2.2.219    domjudge-judgehost28
-10.2.2.220    domjudge-judgehost29
-10.2.2.221    domjudge-judgehost30
-10.2.2.222    domjudge-judgehost31
-10.2.2.223    domjudge-judgehost32
-10.2.2.254    gateway2
 
-#Server Network (10.3.3.0/24)
-10.3.3.1    score1 # windows
-10.3.3.2    score2 # windows
-10.3.3.3    score3 # windows
-10.3.3.4    score4 # windows
-10.3.3.5    score5 # windows
-10.3.3.6    score6 # windows
-10.3.3.7    score7 # windows
-10.3.3.8    score8 # windows
-# Admin Machines
-10.3.3.190    cdsadmin1
-10.3.3.191    cdsadmin2
-10.3.3.192    cdsadmin3
-# ICPC Servers
-10.3.3.199    emergency
-10.3.3.205    reverseproxy
-10.3.3.206    media
-10.3.3.207    cds cds-blue
+#############################################
+# Judge Network - VLAN  20                  #
+# 10.2.2.0/23                               #
+# GW - 10.2.2.1                             #
+#############################################
+10.2.2.1	judge-gateway
+
+# Human judges 10.2.2.11->10.2.2.40
+10.2.2.11	judge1
+10.2.2.12	judge2
+10.2.2.13	judge3
+10.2.2.14	judge4
+10.2.2.15	judge5
+10.2.2.16	judge6
+10.2.2.17	judge7
+10.2.2.18	judge8
+10.2.2.19	judge9
+10.2.2.20	judge10
+10.2.2.21	judge11
+10.2.2.22	judge12
+10.2.2.23	judge13
+10.2.2.24	judge14
+10.2.2.25	judge15
+10.2.2.26	judge16
+10.2.2.27	judge17
+10.2.2.28	judge18
+10.2.2.29	judge19
+10.2.2.30	judge20
+10.2.2.31	judge21
+10.2.2.32	judge22
+10.2.2.33	judge23
+10.2.2.34	judge24
+10.2.2.35	judge25
+10.2.2.36	judge26
+10.2.2.37	judge27
+10.2.2.38	judge28
+10.2.2.39	judge29
+10.2.2.40	judge30
+
+# Kattis AutoJudges
+10.2.2.41	kattis-autojudge1
+10.2.2.42	kattis-autojudge2
+10.2.2.43	kattis-autojudge3
+10.2.2.44	kattis-autojudge4
+10.2.2.45	kattis-autojudge5
+10.2.2.46	kattis-autojudge6
+10.2.2.47	kattis-autojudge7
+10.2.2.48	kattis-autojudge8
+10.2.2.49	kattis-autojudge9
+10.2.2.50	kattis-autojudge10
+10.2.2.51	kattis-autojudge11
+10.2.2.52	kattis-autojudge12
+10.2.2.53	kattis-autojudge13
+10.2.2.54	kattis-autojudge14
+10.2.2.55	kattis-autojudge15
+10.2.2.56	kattis-autojudge16
+10.2.2.57	kattis-autojudge17
+10.2.2.58	kattis-autojudge18
+10.2.2.59	kattis-autojudge19
+10.2.2.60	kattis-autojudge20
+10.2.2.61	kattis-autojudge21
+10.2.2.62	kattis-autojudge22
+10.2.2.63	kattis-autojudge23
+10.2.2.64	kattis-autojudge24
+10.2.2.65	kattis-autojudge25
+10.2.2.66	kattis-autojudge26
+10.2.2.67	kattis-autojudge27
+10.2.2.68	kattis-autojudge28
+10.2.2.69	kattis-autojudge29
+10.2.2.70	kattis-autojudge30
+
+# pc2 aj
+10.2.2.101	pc2-aj1
+10.2.2.102	pc2-aj2
+10.2.2.103	pc2-aj3
+10.2.2.104	pc2-aj4
+10.2.2.105	pc2-aj5
+10.2.2.106	pc2-aj6
+10.2.2.107	pc2-aj7
+10.2.2.108	pc2-aj8
+10.2.2.109	pc2-aj9
+10.2.2.110	pc2-aj10
+10.2.2.111	pc2-aj11
+10.2.2.112	pc2-aj12
+10.2.2.113	pc2-aj13
+10.2.2.114	pc2-aj14
+10.2.2.115	pc2-aj15
+10.2.2.116	pc2-aj16
+10.2.2.117	pc2-aj17
+10.2.2.118	pc2-aj18
+10.2.2.119	pc2-aj19
+10.2.2.120	pc2-aj20
+10.2.2.121	pc2-aj21
+10.2.2.122	pc2-aj22
+10.2.2.123	pc2-aj23
+10.2.2.124	pc2-aj24
+10.2.2.125	pc2-aj25
+10.2.2.126	pc2-aj26
+10.2.2.127	pc2-aj27
+10.2.2.128	pc2-aj28
+10.2.2.129	pc2-aj29
+10.2.2.130	pc2-aj30
+
+# domjudge judgehosts
+10.2.2.151	domjudge-judgehost1
+10.2.2.152	domjudge-judgehost2
+10.2.2.153	domjudge-judgehost3
+10.2.2.154	domjudge-judgehost4
+10.2.2.155	domjudge-judgehost5
+10.2.2.156	domjudge-judgehost6
+10.2.2.157	domjudge-judgehost7
+10.2.2.158	domjudge-judgehost8
+10.2.2.159	domjudge-judgehost9
+10.2.2.160	domjudge-judgehost10
+10.2.2.161	domjudge-judgehost11
+10.2.2.162	domjudge-judgehost12
+10.2.2.163	domjudge-judgehost13
+10.2.2.164	domjudge-judgehost14
+10.2.2.165	domjudge-judgehost15
+10.2.2.166	domjudge-judgehost16
+10.2.2.167	domjudge-judgehost17
+10.2.2.168	domjudge-judgehost18
+10.2.2.169	domjudge-judgehost19
+10.2.2.170	domjudge-judgehost20
+10.2.2.171	domjudge-judgehost21
+10.2.2.172	domjudge-judgehost22
+10.2.2.173	domjudge-judgehost23
+10.2.2.174	domjudge-judgehost24
+10.2.2.175	domjudge-judgehost25
+10.2.2.176	domjudge-judgehost26
+10.2.2.177	domjudge-judgehost27
+10.2.2.178	domjudge-judgehost28
+10.2.2.179	domjudge-judgehost29
+10.2.2.180	domjudge-judgehost30
+
+# 10.2.3.100 - 10.2.3.200 - DHCP Range - Required for Imaging
+
+
+#############################################
+# Server Network - VLAN  30                 #
+# 10.3.2.0/23                               #
+# GW - 10.3.2.1                             #
+#############################################
+
+10.3.2.1 server-gateway
+
+
+# 10.3.2.10-10.3.2.100 - DHCP Range (required for imaging)
+
+
+# 10.3.3.41-70 for kattis-ccsadmin (matches range for Kattis AJs)
+10.3.3.41	kattis-ccsadmin1
+10.3.3.42	kattis-ccsadmin2
+10.3.3.43	kattis-ccsadmin3
+10.3.3.44	kattis-ccsadmin4
+10.3.3.45	kattis-ccsadmin5
+10.3.3.46	kattis-ccsadmin6
+10.3.3.47	kattis-ccsadmin7
+10.3.3.48	kattis-ccsadmin8
+
+# 10.3.3.101-130 for pc2-ccsadmin (matches range for PC2 AJs)
+10.3.3.101	pc2-ccsadmin1
+10.3.3.102	pc2-ccsadmin2
+10.3.3.103	pc2-ccsadmin3
+10.3.3.104	pc2-ccsadmin4
+10.3.3.105	pc2-ccsadmin5
+10.3.3.106	pc2-ccsadmin6
+10.3.3.107	pc2-ccsadmin7
+10.3.3.108	pc2-ccsadmin8
+
+
+# 10.3.3.151-180  for domjudge-ccsadmin (matches range for DomJudge AJs)
+10.3.3.151	domjudge-ccsadmin1
+10.3.3.152	domjudge-ccsadmin2
+10.3.3.153	domjudge-ccsadmin3
+10.3.3.154	domjudge-ccsadmin4
+10.3.3.155	domjudge-ccsadmin5
+10.3.3.156	domjudge-ccsadmin6
+10.3.3.157	domjudge-ccsadmin7
+10.3.3.158	domjudge-ccsadmin8
+
+# ICPC Servers 10.3.3.199-250
+10.3.3.199	emergency-laptop
+10.3.3.207	cds cds-blue
+
+
+
+
 # 10.3.3.208/28 for servers
-10.3.3.208    scoreboard printsrv
-10.3.3.209    packages
-10.3.3.210    backup
-# 10.3.3.211    printsrv
-10.3.3.212    kattis kattismaster kattis-test kattis-dress kattis-final
-10.3.3.213    kattisbackup ccsbackup
-10.3.3.214    pc2
-10.3.3.215    domjudge domserver
-10.3.3.216    domjudge-1
-10.3.3.217    domjudge-2
-10.3.3.222    pc2backup
+10.3.3.208	scoreboard printsrv
+10.3.3.209	packages
+10.3.3.210	backup
+10.3.3.212	kattis kattismaster kattis-test kattis-dress kattis-final
+10.3.3.213	kattisbackup kattis-ccsbackup
+10.3.3.214	pc2
+10.3.3.215	domjudge domserver
+10.3.3.216	domjudge-1
+10.3.3.217	domjudge-2
+10.3.3.222	pc2backup
 
-# 10.3.3.224/29 for domjudge-ccsadmin
-10.3.3.224    domjudge-ccsadmin1
-10.3.3.225    domjudge-ccsadmin2
-10.3.3.226    domjudge-ccsadmin3
-10.3.3.227    domjudge-ccsadmin4
-10.3.3.228    domjudge-ccsadmin5
-10.3.3.229    domjudge-ccsadmin6
-10.3.3.230    domjudge-ccsadmin7
-10.3.3.231    domjudge-ccsadmin8
+10.3.3.240      green-analyst-blueentry
 
-# 10.3.3.232/29 for ccsadmin
-10.3.3.232    ccsadmin1
-10.3.3.233    ccsadmin2
-10.3.3.234    ccsadmin3
-10.3.3.235    ccsadmin4
-10.3.3.236    ccsadmin5
-10.3.3.237    ccsadmin6
-10.3.3.238    ccsadmin7
-10.3.3.239    ccsadmin8
+# 10.3.3.251-254 MGMT systems
+# Management Systems
+10.3.3.251	Troy-MGMT
+10.3.3.252	Keith-MGMT
 
-# 10.3.3.240/29 for pc2-ccsadmin
-10.3.3.240    pc2-ccsadmin1
-10.3.3.241    pc2-ccsadmin2
-10.3.3.242    pc2-ccsadmin3
-10.3.3.243    pc2-ccsadmin4
-10.3.3.244    pc2-ccsadmin5
-10.3.3.245    pc2-ccsadmin6
-10.3.3.246    pc2-ccsadmin7
-10.3.3.247    pc2-ccsadmin8
 
-# 10.3.3.248/29 mostly unused
-10.3.3.254    gateway3
 
-#Print/Balloon Network (10.4.4.0/24)
+#############################################
+# Print/Balloon Net - VLAN  40              #
+# 10.4.4.0/23                               #
+# 10.4.4.1 - Gateway                        #
+#############################################
+#Print/Balloon Network (10.4.4.0/23)
 # balloonmager is on this vlan
 # as it is located by the printers
-10.4.4.149    balloonmanager
+
+10.4.4.1	balloon-gateway
+
+10.4.4.149	balloonmanager
 # 10.4.4.200/29 for printers
-10.4.4.200    balloonprinter
-10.4.4.201    teamprint1
-10.4.4.202    teamprint2
-10.4.4.203    teamprint3
-10.4.4.204    judgeprint
-10.4.4.205    systemsprint
-10.4.4.254    gateway4
-
-#MGMT network (10.5.5.0/24)
-10.5.5.5        sysops_mgmt sysops-mgmt troy
-10.5.5.11    esx1
-10.5.5.12    esx2
-10.5.5.13    esx3
-10.5.5.18    vcenter
-
-10.5.5.90    template
-10.5.5.92    vm2
-10.5.5.94    builder-vlan50
-10.5.5.95    domjudge-green-vlan50
-10.5.5.96    myicpc-vlan50
-10.5.5.97    myicpc2-vlan50
-10.5.5.98    myicpc3-vlan50
-10.5.5.99    myicpc4-vlan50
-10.5.5.100    myicpc5-vlan50
-10.5.5.200    doug
-10.5.5.201    chris
-10.5.5.202    chris2
-10.5.5.254    gateway5
+10.4.4.201	teamprint1
+10.4.4.202	teamprint2
+10.4.4.203	teamprint3
+10.4.4.204	judgeprint
+10.4.4.205	systemsprint
 
 
-#Camera network (10.90.90.0/24)
-10.90.90.1    camera1
-10.90.90.2    camera2
-10.90.90.3    camera3
-10.90.90.4    camera4
-10.90.90.5    camera5
-10.90.90.6    camera6
-10.90.90.7    camera7
-10.90.90.8    camera8
-10.90.90.90    camera_mgmt
+#############################################
+# MGMT Network - VLAN  50                   #
+# 10.5.5.0/23                               #
+# GW - 10.5.4.1                             #
+#############################################
+# - Used primarily for Imaging for Baku
+10.5.4.1	mgmt-gateway
 
-# red network
-# coachview
-172.24.2.80	coachview1
-172.24.2.81	coachview2
-172.24.2.82	coachview3
-172.24.2.83	coachview4
-172.24.2.84	coachview5
-172.24.2.85	coachview6
-172.24.2.86	coachview7
-172.24.2.87	coachview8
-172.24.2.88	coachview9
-172.24.2.89	coachview10
-172.24.2.90	coachview11
-172.24.2.91	coachview12
-172.24.2.92	coachview13
-172.24.2.93	coachview14
-172.24.2.94	coachview15
-172.24.2.95	coachview16
+10.5.5.201	fog-server
+10.5.5.202	fog-slave1
 
-# not 207 because of conflict with live?
-172.24.0.7    cds-red
 
-#Start of the Green Network (172.29.0.0/22)
-172.29.0.1     router
+#############################################
+# Camera Network - VLAN  90                 #
+# 10.90.90.0/23                             #
+# GW - Not needed for this network.         #
+#############################################
 
-# presentantion bits 172.29.0.32/27 (32-63)
-172.29.0.32 PresAdmin
-172.29.0.33 PresClient1
-172.29.0.34 PresClient2
-172.29.0.35 PresClient3
-172.29.0.36 PresClient4
-172.29.0.37 PresClient5
-172.29.0.38 PresClient6
-172.29.0.39 PresClient7
-172.29.0.40 PresClient8
-172.29.0.41 PresClient9
-172.29.0.42 PresClient10
-172.29.0.43 PresClient11
-172.29.0.44 PresClient12
-172.29.0.45 PresClient13
-172.29.0.46 PresClient14
-172.29.0.47 PresClient15
-172.29.0.48 PresClient16
-172.29.0.49 PresClient17
-172.29.0.50 PresClient18
-172.29.0.50 PresClient19
-172.29.0.50 PresClient20
-172.29.0.50 PresClient21
-172.29.0.50 PresClient22
-172.29.0.50 PresClient23
-172.29.0.50 PresClient24
-172.29.0.50 PresClient25
-172.29.0.50 PresClient26
-172.29.0.50 PresClient27
-172.29.0.60 PresClient28
-172.29.0.61 PresClient29
-172.29.0.62 PresClient30
-172.29.0.63 PresClient31
+10.90.90.1	camera1
+10.90.90.2	camera2
+10.90.90.3	camera3
+10.90.90.4	camera4
+10.90.90.5	camera5
+10.90.90.6	camera6
+10.90.90.7	camera7
+10.90.90.8	camera8
+10.90.90.90	camera_mgmt
 
-# 172.29.0.100 - 172.29.0.149 ICPCLive
+
+#############################################
+# Green - VLAN  100                         #
+# 172.29.0.0/22                             #
+#############################################
+
+172.29.0.1	green-gateway
+
+# presentation bits 172.29.0.30-61
+172.29.0.30	PresAdmin
+172.29.0.31	PresClient1
+172.29.0.32	PresClient2
+172.29.0.33	PresClient3
+172.29.0.34	PresClient4
+172.29.0.35	PresClient5
+172.29.0.36	PresClient6
+172.29.0.37	PresClient7
+172.29.0.38	PresClient8
+172.29.0.39	PresClient9
+172.29.0.40	PresClient10
+172.29.0.41	PresClient11
+172.29.0.42	PresClient12
+172.29.0.43	PresClient13
+172.29.0.44	PresClient14
+172.29.0.45	PresClient15
+172.29.0.46	PresClient16
+172.29.0.47	PresClient17
+172.29.0.48	PresClient18
+172.29.0.49	PresClient19
+172.29.0.50	PresClient20
+172.29.0.51	PresClient21
+172.29.0.52	PresClient22
+172.29.0.53	PresClient23
+172.29.0.54	PresClient24
+172.29.0.55	PresClient25
+172.29.0.56	PresClient26
+172.29.0.57	PresClient27
+172.29.0.58	PresClient28
+172.29.0.59	PresClient29
+172.29.0.60	PresClient30
+172.29.0.61	PresClient31
 
 # Analysts
-# 172.29.0.160/27 upto 191
-172.29.0.160 analyst1
-172.29.0.161 analyst2
-172.29.0.162 analyst3
-172.29.0.163 analyst4
-172.29.0.164 analyst5
-172.29.0.165 analyst6
-172.29.0.166 analyst7
-172.29.0.167 analyst8
-172.29.0.168 analyst9
-172.29.0.169 analyst10
-172.29.0.170 analyst11
-172.29.0.171 analyst12
-172.29.0.172 analyst13
-172.29.0.173 analyst14
-172.29.0.174 analyst15
-172.29.0.175 analyst16
-172.29.0.176 analyst17
-172.29.0.177 analyst18
-172.29.0.178 analyst19
-172.29.0.179 analyst20
-172.29.0.180 analyst21
-172.29.0.181 analyst22
-172.29.0.182 analyst23
-172.29.0.183 analyst24
-172.29.0.184 analyst25
-172.29.0.185 analyst26
-172.29.0.186 analyst27
-172.29.0.187 analyst28
-172.29.0.188 analyst29
-172.29.0.189 analyst30
-172.29.0.190 analyst31
-172.29.0.191 icat
+# 172.29.0.161 -191
+172.29.0.161	analyst1
+172.29.0.162	analyst2
+172.29.0.163	analyst3
+172.29.0.164	analyst4
+172.29.0.165	analyst5
+172.29.0.166	analyst6
+172.29.0.167	analyst7
+172.29.0.168	analyst8
+172.29.0.169	analyst9
+172.29.0.170	analyst10
+172.29.0.171	analyst11
+172.29.0.172	analyst12
+172.29.0.173	analyst13
+172.29.0.174	analyst14
+172.29.0.175	analyst15
+172.29.0.176	analyst16
+172.29.0.177	analyst17
+172.29.0.178	analyst18
+172.29.0.179	analyst19
+172.29.0.180	analyst20
+172.29.0.181	analyst21
+172.29.0.182	analyst22
+172.29.0.183	analyst23
+172.29.0.184	analyst24
+172.29.0.185	analyst25
+172.29.0.186	analyst26
+172.29.0.187	analyst27
+172.29.0.188	analyst28
+172.29.0.189	analyst29
+172.29.0.190	analyst30
+172.29.0.191	analyst31
+172.29.0.192 	icat
 
 
-172.29.1.15    sniffer-vm01
-172.29.1.16    redirect1-green
-172.29.1.20  clock
-172.29.1.50  Sysops Printer?
+172.29.1.20	clock
+172.29.1.50	sysops-printer
 
 # These only exist temporarily on the network to get provisioned/set up
 172.29.1.60 resolver-presenter
 172.29.1.61 resolver-client
 
-172.29.1.63 green-presadmin1
-172.29.1.64 green-presclient1
-172.29.1.65 green-presclient2
-172.29.1.66 green-presclient3
-172.29.1.67 green-presclient4
-172.29.1.68 green-presclient5
-172.29.1.69 green-presclient6
-172.29.1.70 green-presclient7
-172.29.1.71 green-presclient8
-172.29.1.72 green-presclient9
-172.29.1.73 green-presclient10
-172.29.1.74 green-presclient11
-172.29.1.75 green-presclient12
-
-172.29.1.101         Netmon
-172.29.1.191    builder
-172.29.1.192    myicpc2
-172.29.1.193    myicpc3
-172.29.1.194    myicpc4
-172.29.1.195    myicpc5
-172.29.1.206    myicpc
+172.29.1.101	Netmon
+172.29.1.191	builder
 172.29.1.207   cds-green
 172.29.1.208   scoreboard-green
 172.29.1.209   packages-green
 172.29.1.210   backup-green
-172.29.1.211   nisprint-green
-172.29.1.215   green
-172.29.1.216   green-ccsadmin1
-172.29.1.217   green-ccsadmin2
-172.29.1.218   green-ccsadmin3
-172.29.1.220   green-judgemaster
-172.29.1.221   green-judgehost1
-172.29.1.222   green-judgehost2
-172.29.1.223   green-judgehost3
-172.29.1.224   green-judgehost4
-172.29.1.225   green-judgehost5
-172.29.1.226   green-judgehost6
-172.29.1.227   green-judgehost7
-172.29.1.228   green-judgehost8
-172.29.1.229   green-judgehost9
-172.29.1.245   media1-green
-172.29.1.250   gview-green
-172.29.1.251   analysts-green
 
-172.29.2.5    CloudKeyManagement-hynan
+172.29.1.221  green-judgehost1
+172.29.1.222  green-judgehost2
+172.29.1.223  green-judgehost3
+172.29.1.224  green-judgehost4
+172.29.1.225  green-judgehost5
+172.29.1.226  green-judgehost6
+172.29.1.227  green-judgehost7
+172.29.1.228  green-judgehost8
+
+
+
+
+# 172.29.2.5    CloudKeyManagement-hynan
 # 172.29.2.10 - 172.29.3.200 - DHCP Range
 # 172.29.3.201-172.29.3.250 - Switch MGMT area
 # 172.29.3.251 - FOG/Imaging Server
 
-#VPN VLAN NETWORKS
-# MORE COMING HERE...
+# DHCP Range
+# 172.29.2.10 - 172.29.3.180 - DHCP Range
+
+# Switch/Management section - 172.29.3.181-250
+# To be updated once we have details on the hardware for Baku
+# 172.29.3.181-199	Access Points
+# 172.29.3.181	Green AP - SysOps TechOps
+# 172.29.3.195	Server8PortDist2
+# 172.29.3.196	Server8PortDist1
+# 172.29.3.197	Server room 2 copper dist
+# 172.29.3.198	Server Room Copper Dist
+# 172.29.3.199	Server Room Switch
+# 172.29.3.200	ICPC Firewall
+# 172.29.3.201	SFP+ Core Distribution Switch
+# 172.29.3.202	TechOps Distribution Switch
+# 172.29.3.211	TS1
+# 172.29.3.212	TS2
+# 172.29.3.213	TS3
+# 172.29.3.214	TS4
+# 172.29.3.215	TS5
+# 172.29.3.216	TS6
+# 172.29.3.217	TS7
+# 172.29.3.218	TS8
+
+
+# 172.29.3.251	Config Switch IP Address
+# 172.29.3.252	UnifFi Controler - Laptop
+
+
+#############################################
+# Yellow Network - VLAN 150                 #
+#     ICPC Staff network (Office, etc)      #
+# 172.20.0.0/22                             #
+# Gateway - 172.20.0.1                      #
+#############################################
+172.20.0.1     yellow-gateway
+
+# 172.20.1.9	Office AP
+# 172.20.1.10-172.20.2.200 - DHCP Range
+
+
+
+#############################################
+# Red Network - VLAN 200                    #
+# 172.24.0.0/22                             #
+# Gateway - 172.24.0.1                      #
+#############################################
+
+172.24.0.1     red-gateway
+
+# 172.24.0.100 - 172.24.0.149 ICPCLive
+# Static 172.24.0.2-172.24.0.254 - ICPC Live
+# 172.24.0.207	CDS Red
+# 172.24.0.245	Media MTX server - Live
+# 172.24.0.251	Live Camera
+# 172.24.0.252	Live Camera (TBD depending on number of devices)
+# TBD - Overlay server
+
+
+
+# Digital Signage 172.24.1.0-172.24.1.246
+# 172.24.1.0 - 172.24.1.246
+
+# CoachView
+# 172.24.2.80-95	CoachView systems
+172.24.2.81	coachview1
+172.24.2.82	coachview2
+172.24.2.83	coachview3
+172.24.2.84	coachview4
+172.24.2.85	coachview5
+172.24.2.86	coachview6
+172.24.2.87	coachview7
+172.24.2.88	coachview8
+172.24.2.89	coachview9
+172.24.2.90	coachview10
+172.24.2.91	coachview11
+172.24.2.92	coachview12
+172.24.2.93	coachview13
+172.24.2.94	coachview14
+172.24.2.95	coachview15
+172.24.2.96	coachview16
+
+
+# ICPC News
+172.24.2.101       ICPCNews-Server
+
+# DHCP - Red
+# 172.24.2.150-172.24.3.200
+# 172.24.3.201 Video Gateway
+# 172.24.3.202 Video Gateway 2
+
+# 172.24.3.230-250  Switch/AP range
+
+
+
+###Local hosts file
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters

--- a/roles/icpc_host_packages/files/nginx.packages.conf
+++ b/roles/icpc_host_packages/files/nginx.packages.conf
@@ -1,18 +1,38 @@
+
 server {
-        listen 443 ssl http2;
-        server_name packages;
-        ssl_certificate /etc/ssl/certs/packages.pem;
-        ssl_certificate_key /etc/ssl/private/packages.key;
+  listen 443 ssl http2;
+  server_name packages;
+  ssl_certificate /etc/ssl/certs/packages.pem;
+  ssl_certificate_key /etc/ssl/private/packages.key;
 
-        root     /var/www/html/;
+  root     /var/www/html/;
 
-        # Tune some buffer settings
-        proxy_buffer_size 16k;
-        proxy_busy_buffers_size 24k;
-        proxy_buffers 64 4k;
+  location / {
+    # Use local files if we have them, otherwise try to fetch from upstream
+    try_files $uri @mirror;
+  }
 
-        # Set the hostname as a variable, this forces nginx to do a dns lookup
-        # otherwise it only looks it up when it starts and never refreshes it
-        set $server_host "https://packages";
+  # Set the hostname as a variable, this forces nginx to do a dns lookup
+  # otherwise it only looks it up when it starts and never refreshes it
+  resolver 8.8.8.8 ipv6=off;
+  set $server_host "https://sysopspackages.icpc.global";
+  location @mirror {
+    # Pass the request upstream
+    proxy_pass $server_host$request_uri;
+    proxy_ssl_name "sysopspackages.icpc.global";
+    proxy_ssl_server_name on;
+    proxy_set_header Host "sysopspackages.icpc.global";
 
+    # Force caching by ignoring upstream cache control headers
+    proxy_ignore_headers Cache-Control Expires Set-Cookie;
+    proxy_hide_header Cache-Control;
+    proxy_hide_header Expires;
+    proxy_hide_header Set-Cookie;
+    # Skip If-Modified-Since header (always request from upstream)
+    proxy_set_header If-Modified-Since "";
+
+    # Save the responses so we can serve them out later
+    proxy_store on;
+    proxy_store_access user:rw group:rw all:r;
+   }
 }

--- a/roles/icpc_host_packages/handlers/main.yml
+++ b/roles/icpc_host_packages/handlers/main.yml
@@ -1,8 +1,8 @@
 ---
-- name: Reload nginx
+- name: Restart nginx
   ansible.builtin.service:
     name: nginx
-    state: reloaded
+    state: restarted
 
 - name: Systemd-resolved
   ansible.builtin.service:

--- a/roles/icpc_host_packages/tasks/main.yml
+++ b/roles/icpc_host_packages/tasks/main.yml
@@ -32,6 +32,13 @@
       - ssl-cert
     state: present
 
+- name: Ensure permissions on the web directory
+  ansible.builtin.file:
+    path: /var/www/html
+    owner: www-data
+    group: www-data
+    mode: '0755'
+
 - name: Configure nginx for packages
   block:
     - name: Install packages.pem
@@ -39,7 +46,7 @@
         src: "/root/ca/intermediate/certs/packages{{ keyprefix | default('') }}.cert.pem"
         dest: /etc/ssl/certs/packages.pem
         mode: '0644'
-      notify: Reload nginx
+      notify: Restart nginx
 
     - name: Install packages.key
       ansible.builtin.copy:
@@ -47,24 +54,24 @@
         dest: /etc/ssl/private/packages.key
         group: ssl-cert
         mode: '0640'
-      notify: Reload nginx
+      notify: Restart nginx
 
     - name: Install sites-available/packages.conf
       ansible.builtin.copy:
         src: files/nginx.packages.conf
         dest: /etc/nginx/sites-available/packages.conf
         mode: '0644'
-      notify: Reload nginx
+      notify: Restart nginx
 
     - name: Link sites-available to sites-enabled
       ansible.builtin.file:
         dest: /etc/nginx/sites-enabled/packages.conf
         src: /etc/nginx/sites-available/packages.conf
         state: link
-      notify: Reload nginx
+      notify: Restart nginx
 
     - name: Remove default site
       ansible.builtin.file:
         path: /etc/nginx/sites-enabled/default
         state: absent
-      notify: Reload nginx
+      notify: Restart nginx

--- a/roles/icpc_host_packages/templates/iptables.rules.j2
+++ b/roles/icpc_host_packages/templates/iptables.rules.j2
@@ -87,6 +87,8 @@
 # -A INPUT -m state --state ESTABLISHED,RELATED -j accept-in-log
 # -A OUTPUT -m state --state NEW,ESTABLISHED,RELATED -j accept-out-log
 
+{{ extra_iptables_rules | default([]) | join("\n") }}
+
 # drop rest
 -A OUTPUT -j drop-n-log
 -A INPUT -j drop-n-log

--- a/roles/script_server/lookup_plugins/ip.py
+++ b/roles/script_server/lookup_plugins/ip.py
@@ -22,4 +22,10 @@ class LookupModule(LookupBase):
         if not isinstance(hostname, str):
             raise errors.AnsibleError("ip lookup expects a string (hostname)")
 
-        return [socket.gethostbyname(hostname)]
+        try:
+            retval = [socket.gethostbyname(hostname)]
+        except Exception:
+            # raise errors.AnsibleError("Unable to resolve hostname %s" % hostname)
+            return []
+
+        return retval

--- a/roles/script_server/templates/conf.json.j2
+++ b/roles/script_server/templates/conf.json.j2
@@ -5,16 +5,17 @@
         "trusted_ips": [
             {% for group in groups if group not in script_server_ignored_groups %}
             {%- for host in groups[group] -%}
-            "{{ hostvars[host].ansible_host}}",
+            "{{ lookup('ip', host, errors='ignore', wantlist=True) | first | default(hostvars[host].ansible_host) }}",
             {% endfor %}
             {%- endfor -%}
 
-            {% for u in script_server_admin_users %}"{{ lookup('ip', u)}}", {% endfor %}"127.0.0.1"
+            {% for u in script_server_admin_users %}"{{ lookup('ip', u)}}", {% endfor %}
+            "127.0.0.1"
         ],
         "allowed_users": [
             {% for group in groups if group not in script_server_ignored_groups %}
             {%- for host in groups[group] -%}
-            "{{ hostvars[host].ansible_host}}",
+            "{{ lookup('ip', host, errors='ignore', wantlist=True) | first | default(hostvars[host].ansible_host) }}",
             {% endfor -%}
             {%- endfor -%}
             "127.0.0.1"
@@ -24,7 +25,7 @@
             {% for group in groups if group not in script_server_ignored_groups -%}
             "{{group}}": [
                 {% for host in groups[group] -%}
-                "{{ hostvars[host].ansible_host}}" {{ ", " if not loop.last else "" }}
+                "{{ lookup('ip', host, errors='ignore', wantlist=True) | first | default(hostvars[host].ansible_host) }}" {{ ", " if not loop.last else "" }}
                 {% endfor -%}
             ],
             {% endfor -%}

--- a/roles/ssh_ca/defaults/main.yml
+++ b/roles/ssh_ca/defaults/main.yml
@@ -1,0 +1,1 @@
+ssh_ca_dir: /root/ssh-ca

--- a/roles/ssh_ca/handlers/main.yml
+++ b/roles/ssh_ca/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Restart sshd
+  ansible.builtin.systemd:
+    name: sshd
+    state: restarted

--- a/roles/ssh_ca/tasks/ca.yml
+++ b/roles/ssh_ca/tasks/ca.yml
@@ -1,0 +1,20 @@
+---
+- name: Ensure the ssh-ca directory exists
+  ansible.builtin.file:
+    path: "{{ ssh_ca_dir }}/{{ item }}"
+    state: directory
+    mode: "0700"
+  with_items:
+    - hosts
+    - users
+
+- name: Generate SSH Host+User CAs
+  ansible.builtin.command: >
+    ssh-keygen -t ed25519
+      -f {{ ssh_ca_dir }}/{{ item }}_ca
+      -C {{ item }}_ca
+  args:
+    creates: "{{ ssh_ca_dir }}/{{ item }}_ca"
+  with_items:
+    - host
+    - user

--- a/roles/ssh_ca/tasks/main.yml
+++ b/roles/ssh_ca/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: Fetch the SSH Host Key for {{ inventory_hostname }}
+  ansible.builtin.fetch:
+    src: /etc/ssh/ssh_host_ed25519_key.pub
+    dest: "{{ ssh_ca_dir }}/hosts/{{inventory_hostname}}.key.pub"
+    flat: true
+  register: fetch_ssh_host_key
+
+- name: Check if the host key cert already exists
+  ansible.builtin.stat:
+    path: "{{ ssh_ca_dir }}/hosts/{{ inventory_hostname }}.key-cert.pub"
+  register: stat_host_key
+
+- name: Sign the SSH Host Key for {{ inventory_hostname }}
+  ansible.builtin.command: >-
+    ssh-keygen
+      -s {{ ssh_ca_dir }}/host_ca
+      -I "icpc-wf CA"
+      -h
+      -n "{{ inventory_hostname }}"
+      "{{ ssh_ca_dir }}/hosts/{{ inventory_hostname }}.key.pub"
+  delegate_to: localhost
+  when: fetch_ssh_host_key is changed or not stat_host_key.stat.exists
+
+- name: Copy SSH Host Cert for {{ inventory_hostname }}
+  ansible.builtin.copy:
+    src: "{{ ssh_ca_dir }}/hosts/{{ inventory_hostname }}.key-cert.pub"
+    dest: /etc/ssh/{{ inventory_hostname }}.key-cert.pub
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart sshd
+
+
+- name: Trust the ssh ca in known_hosts
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/ssh_known_hosts
+    line: "@cert-authority * {{ lookup('file', '{{ ssh_ca_dir }}/host_ca.pub') }}"
+    create: yes
+    mode: "0644"
+- name: Add the CA to the TrustedCAKeys file
+  ansible.builtin.copy:
+    src: "{{ ssh_ca_dir }}/user_ca.pub"
+    dest: /etc/ssh/TrustedCAKeys
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Update sshd_config to use the host cert
+  ansible.builtin.copy:
+    content: |
+      HostCertificate /etc/ssh/{{ inventory_hostname }}.key-cert.pub
+    dest: /etc/ssh/sshd_config.d/99-host-cert.conf
+  notify: Restart sshd
+
+- name: Update sshd_config to trust the user CA and support .ssh/authorized_principals
+  ansible.builtin.copy:
+    content: |
+      TrustedUserCAKeys /etc/ssh/TrustedCAKeys
+      AuthorizedPrincipalsFile .ssh/authorized_principals
+    dest: /etc/ssh/sshd_config.d/99-user-ca.conf
+  notify: Restart sshd

--- a/roles/ssh_ca/tasks/main.yml
+++ b/roles/ssh_ca/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Fetch the SSH Host Key for {{ inventory_hostname }}
   ansible.builtin.fetch:
     src: /etc/ssh/ssh_host_ed25519_key.pub
-    dest: "{{ ssh_ca_dir }}/hosts/{{inventory_hostname}}.key.pub"
+    dest: "{{ ssh_ca_dir }}/hosts/{{ inventory_hostname }}.key.pub"
     flat: true
   register: fetch_ssh_host_key
 
@@ -11,7 +11,7 @@
     path: "{{ ssh_ca_dir }}/hosts/{{ inventory_hostname }}.key-cert.pub"
   register: stat_host_key
 
-- name: Sign the SSH Host Key for {{ inventory_hostname }}
+- name: Sign the SSH Host Key for {{ inventory_hostname }} # noqa: no-changed-when
   ansible.builtin.command: >-
     ssh-keygen
       -s {{ ssh_ca_dir }}/host_ca
@@ -36,7 +36,7 @@
   ansible.builtin.lineinfile:
     path: /etc/ssh/ssh_known_hosts
     line: "@cert-authority * {{ lookup('file', '{{ ssh_ca_dir }}/host_ca.pub') }}"
-    create: yes
+    create: true
     mode: "0644"
 - name: Add the CA to the TrustedCAKeys file
   ansible.builtin.copy:
@@ -51,6 +51,9 @@
     content: |
       HostCertificate /etc/ssh/{{ inventory_hostname }}.key-cert.pub
     dest: /etc/ssh/sshd_config.d/99-host-cert.conf
+    owner: root
+    group: root
+    mode: "0644"
   notify: Restart sshd
 
 - name: Update sshd_config to trust the user CA and support .ssh/authorized_principals
@@ -59,4 +62,7 @@
       TrustedUserCAKeys /etc/ssh/TrustedCAKeys
       AuthorizedPrincipalsFile .ssh/authorized_principals
     dest: /etc/ssh/sshd_config.d/99-user-ca.conf
+    owner: root
+    group: root
+    mode: "0644"
   notify: Restart sshd

--- a/roles/ssh_ca/tasks/user.yml
+++ b/roles/ssh_ca/tasks/user.yml
@@ -1,0 +1,32 @@
+---
+- name: Stat the user key to sign
+  ansible.builtin.stat:
+    path: "{{ ssh_key_to_sign }}"
+  register: user_key_stat
+
+- name: Copy user key locally
+  ansible.builtin.fetch:
+    src: "{{ ssh_key_to_sign }}"
+    dest: "{{ ssh_ca_dir }}/users/{{ ssh_principal }}.pub"
+    flat: true
+  register: fetch_user_pubkey
+
+- name: Sign the user pubkey
+  ansible.builtin.command:
+    cmd: >
+      ssh-keygen
+            -s {{ ssh_ca_dir }}/user_ca
+            -I {{ ssh_principal }}
+            -n {{ ssh_principal }}
+            -O source-address="{% for ip in ansible_all_ipv4_addresses %}{{ ip }}/32{% if not loop.last %},{% endif %}{% endfor %}"
+            {{ ssh_ca_dir }}/users/{{ ssh_principal }}.pub
+  delegate_to: localhost
+  when: fetch_user_pubkey is changed
+
+- name: Copy signed user pubkey back
+  ansible.builtin.copy:
+    src: "{{ ssh_ca_dir }}/users/{{ ssh_principal }}-cert.pub"
+    dest: "{{ ssh_key_to_sign | regex_replace('\\.pub$', '-cert.pub') }}"
+    owner: "{{ user_key_stat.stat.pw_name }}"
+    group: "{{ user_key_stat.stat.gr_name }}"
+    mode: "0600"

--- a/roles/ssh_ca/tasks/user.yml
+++ b/roles/ssh_ca/tasks/user.yml
@@ -11,7 +11,12 @@
     flat: true
   register: fetch_user_pubkey
 
-- name: Sign the user pubkey
+- name: Check if the user key cert already exists
+  ansible.builtin.stat:
+    path: "{{ ssh_ca_dir }}/users/{{ ssh_principal }}.key-cert.pub"
+  register: stat_user_key
+
+- name: Sign the user pubkey # noqa: no-changed-when
   ansible.builtin.command:
     cmd: >
       ssh-keygen
@@ -21,7 +26,7 @@
             -O source-address="{% for ip in ansible_all_ipv4_addresses %}{{ ip }}/32{% if not loop.last %},{% endif %}{% endfor %}"
             {{ ssh_ca_dir }}/users/{{ ssh_principal }}.pub
   delegate_to: localhost
-  when: fetch_user_pubkey is changed
+  when: fetch_user_pubkey is changed or not stat_user_key.stat.exists
 
 - name: Copy signed user pubkey back
   ansible.builtin.copy:


### PR DESCRIPTION
Ok, I've got a whole pile of things to improve for baku this year. I organized the commits nicely, so reviewing commit by commit is probably the way to go.

Summary of changes:
* Gitserver bootstraps/fetches the repos it's supposed to have
* Fix script-server to work with new optimized ansible inventory
* Various bits of cleanup
* Make packages a proxying cache for sysopspackages.icpc.global. If you have the files, it'll use them, if it doesn't, it'll fetch them.
* Properly configure the cds including extra files
* Simplify fetching release assets from github (including caching and whatnot)
* Update the hosts file
* Create/Configure an ssh ca, so we don't have to mess with known_hosts, and also create an ssh keypair + certificate for the icpc user on all non-contestant machines. Other hosts may add icpc@hostname to their ~/.ssh/authorized_principals file to allow seamless access without setting up keys manually.